### PR TITLE
Remove unused it-pushable dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "iso-random-stream": "^1.1.1",
     "it-block": "^2.0.0",
     "it-pipe": "^1.1.0",
-    "it-pushable": "^1.4.0",
     "it-reader": "^2.1.0",
     "p-defer": "^3.0.0",
     "random-int": "^2.0.0",


### PR DESCRIPTION
Trying to audit where it-pushable is used and came across this. It really looks unused (no occurrences in this module). If this is wrong, please could you share how one can determine that this dependency is live?

Thanks.